### PR TITLE
Added default events (#4) and fixed comments (#3)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -77,7 +77,7 @@ import { ForkTransporter } from 'fork-transporter';
 #### Constructor
 
 ```typescript
-const childTransporter = new ForkTransporter(childProcess);
+const forkTransporter = new ForkTransporter(childProcess);
 ```
 
 Instantiate a ForkTransporter class by passing in a child process that you want to create a transporter for.
@@ -85,7 +85,7 @@ Instantiate a ForkTransporter class by passing in a child process that you want 
 ### Emit
 
 ```typescript
-childTransporter.emit('command', {
+forkTransporter.emit('command', {
     ...
 })
 ```
@@ -95,13 +95,13 @@ Emits a message to the child process. First parameter is the command and the sec
 ### Channel
 
 ```typescript
-const commandChannel = childTransporter.channel('command');
+const commandChannel = forkTransporter.channel('command');
 ```
 
 Channel method exposes an RxJS Observable which filters for the command specified. At this point, you can alter the Observable just like how you would normally.
 
 ```typescript
-const channelSubscription = childTransporter.channel('command')
+const channelSubscription = forkTransporter.channel('command')
     .subscribe(({ command, data }) => {
         ...
     });

--- a/lib/BaseTransporter.ts
+++ b/lib/BaseTransporter.ts
@@ -21,7 +21,7 @@ export abstract class BaseTransporter {
 
     public abstract channel(command: string): Observable<Message>;
 
-    protected createMessagePayload(command, data?: any) {
+    protected createMessagePayload(command, data: any = {}) {
         return {
             command,
             data,

--- a/lib/BaseTransporter.ts
+++ b/lib/BaseTransporter.ts
@@ -21,6 +21,13 @@ export abstract class BaseTransporter {
 
     public abstract channel(command: string): Observable<Message>;
 
+    protected createMessagePayload(command, data?: any) {
+        return {
+            command,
+            data,
+        };
+    }
+
     protected log(msg: any) {
         if (this.allowLogging && this.logger) {
             this.logger(`${this.Name} : ${msg}`);

--- a/lib/ForkTransporter.ts
+++ b/lib/ForkTransporter.ts
@@ -68,7 +68,10 @@ export class ForkTransporter extends BaseTransporter {
 
             // Listens for 'close' events
             this.process.on('close', (code: number, signal: string) => {
-                observer.next(this.createMessagePayload(ChildEvent.CLOSE, { code, signal }));
+                observer.next(this.createMessagePayload(ChildEvent.CLOSE, {
+                    code,
+                    signal,
+                }));
             });
 
             // Listens for 'disconnect' events
@@ -78,12 +81,17 @@ export class ForkTransporter extends BaseTransporter {
 
             // Listens for 'error' events
             this.process.on('error', (error: Error) => {
-                observer.next(this.createMessagePayload(ChildEvent.ERROR, { error }));
+                observer.next(this.createMessagePayload(ChildEvent.ERROR, {
+                    error,
+                }));
             });
 
             // Listens for 'exit' events
             this.process.on('exit', (code: number, signal: string) => {
-                observer.next(this.createMessagePayload(ChildEvent.EXIT, { code, signal }));
+                observer.next(this.createMessagePayload(ChildEvent.EXIT, {
+                    code,
+                    signal,
+                }));
             });
         });
 

--- a/lib/ForkTransporter.ts
+++ b/lib/ForkTransporter.ts
@@ -9,7 +9,7 @@ import { Message } from './tools/Message';
  * Creates wrapper around a child process for easy ipc communication
  *
  * @export
- * @class ChildTransporter
+ * @class ForkTransporter
  */
 export class ForkTransporter extends BaseTransporter {
 
@@ -17,9 +17,9 @@ export class ForkTransporter extends BaseTransporter {
     private process: ChildProcess;
 
     /**
-     * Creates an instance of ChildTransporter.
+     * Creates an instance of ForkTransporter.
      *
-     * @memberof ChildTransporter
+     * @memberof ForkTransporter
      */
     public constructor(process: ChildProcess, logger?: any, allowLogging?: boolean) {
         super(logger, allowLogging);
@@ -34,7 +34,7 @@ export class ForkTransporter extends BaseTransporter {
      *
      * @param {string} command
      * @returns {Observable}
-     * @memberof ChildTransporter
+     * @memberof ForkTransporter
      */
     public channel(command: string) {
         return this._channel
@@ -56,7 +56,7 @@ export class ForkTransporter extends BaseTransporter {
      * Setup command channel
      *
      * @private
-     * @memberof ChildTransporter
+     * @memberof ForkTransporter
      */
     private setup() {
         // Create observable to receive all mesages from parent process

--- a/lib/ForkTransporter.ts
+++ b/lib/ForkTransporter.ts
@@ -48,10 +48,7 @@ export class ForkTransporter extends BaseTransporter {
      * @memberof ForkTransporter
      */
     public emit(command: string, data: any = {}) {
-        this.process.send({
-            command,
-            data,
-        });
+        this.process.send(this.createMessagePayload(command, data));
     }
 
     /**

--- a/lib/ForkTransporter.ts
+++ b/lib/ForkTransporter.ts
@@ -77,8 +77,8 @@ export class ForkTransporter extends BaseTransporter {
             });
 
             // Listens for 'error' events
-            this.process.on('error', (err: Error) => {
-                observer.next(this.createMessagePayload(ChildEvent.ERROR, { err }));
+            this.process.on('error', (error: Error) => {
+                observer.next(this.createMessagePayload(ChildEvent.ERROR, { error }));
             });
 
             // Listens for 'exit' events

--- a/lib/Transporter.ts
+++ b/lib/Transporter.ts
@@ -80,33 +80,37 @@ export class Transporter extends BaseTransporter {
 
             // Listens for 'exit' events
             process.on('exit', (code: number) => {
-                observer.next(this.createMessagePayload(ParentEvent.EXIT, { code }));
+                observer.next(this.createMessagePayload(ParentEvent.EXIT, {
+                    code,
+                }));
             });
 
             // Listens for 'warning' events
             process.on('warning', (warning: Error) => {
-                observer.next(this.createMessagePayload(ParentEvent.WARNING, { warning }));
+                observer.next(this.createMessagePayload(ParentEvent.WARNING, {
+                    warning,
+                }));
             });
 
             // Listens for 'rejectionHandled' events
-            // TODO: Find out why a promise object will not go through the observable
-            // process.on('rejectionHandled', (promise: Promise<any>) => {
-            //     observer.next(this.createMessagePayload(ParentEvent.REJECTION_HANDLED, { promise }));
-            // });
+            process.on('rejectionHandled', (promise: Promise<any>) => {
+                observer.next(this.createMessagePayload(ParentEvent.REJECTION_HANDLED, {
+                    promise,
+                }));
+            });
 
             // Listens for 'unhandledRejection' events
-            // TODO: Find out why a promise object will not go through the observable
-            // process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
-            //     observer.next(this.createMessagePayload(ParentEvent.UNHANDLED_REJECTION, {
-            //         promise,
-            //         reason: JSON.stringify(reason, Object.getOwnPropertyNames(reason)),
-            //     }));
-            // });
+            process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
+                observer.next(this.createMessagePayload(ParentEvent.UNHANDLED_REJECTION, {
+                    promise,
+                    reason,
+                }));
+            });
 
             // Listens for 'uncaughtException' events
             process.on('uncaughtException', (error: Error) => {
                 observer.next(this.createMessagePayload(ParentEvent.UNCAUGHT_EXCEPTION, {
-                    error: JSON.stringify(error, Object.getOwnPropertyNames(error)),
+                    error,
                 }));
             });
 

--- a/lib/Transporter.ts
+++ b/lib/Transporter.ts
@@ -46,13 +46,9 @@ export class Transporter extends BaseTransporter {
      */
     public emit(command: string, data: any = {}) {
         this.log(`Emitting command. [command: ${command}] [data: ${JSON.stringify(data)}]`);
+
         if (process.send) {
-            process.send({
-                command,
-                data,
-            }, (cbData) => {
-                this.log('Callback from emit: ' + cbData);
-            });
+            process.send(this.createMessagePayload(command, data));
         } else {
             this.log('Could not emit command. There is no parent process');
         }

--- a/lib/Transporter.ts
+++ b/lib/Transporter.ts
@@ -89,18 +89,25 @@ export class Transporter extends BaseTransporter {
             });
 
             // Listens for 'rejectionHandled' events
-            process.on('rejectionHandled', (promise: Promise<any>) => {
-                observer.next(this.createMessagePayload(ParentEvent.REJECTION_HANDLED, { }));
-            });
+            // TODO: Find out why a promise object will not go through the observable
+            // process.on('rejectionHandled', (promise: Promise<any>) => {
+            //     observer.next(this.createMessagePayload(ParentEvent.REJECTION_HANDLED, { promise }));
+            // });
 
             // Listens for 'unhandledRejection' events
-            process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
-                observer.next(this.createMessagePayload(ParentEvent.UNHANDLED_REJECTION, { reason, promise }));
-            });
+            // TODO: Find out why a promise object will not go through the observable
+            // process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
+            //     observer.next(this.createMessagePayload(ParentEvent.UNHANDLED_REJECTION, {
+            //         promise,
+            //         reason: JSON.stringify(reason, Object.getOwnPropertyNames(reason)),
+            //     }));
+            // });
 
             // Listens for 'uncaughtException' events
             process.on('uncaughtException', (error: Error) => {
-                observer.next(this.createMessagePayload(ParentEvent.UNCAUGHT_EXCEPTION, { error }));
+                observer.next(this.createMessagePayload(ParentEvent.UNCAUGHT_EXCEPTION, {
+                    error: JSON.stringify(error, Object.getOwnPropertyNames(error)),
+                }));
             });
 
         });

--- a/lib/Transporter.ts
+++ b/lib/Transporter.ts
@@ -68,12 +68,15 @@ export class Transporter extends BaseTransporter {
                 observer.next(data);
             });
 
+            // TODO: Find out why the Observable prevents the process
+            //  from exitting when no work is scheduled
             // Listens for 'beforeExit' events
-            process.on('beforeExit', (code: number) => {
-                observer.next(this.createMessagePayload(ParentEvent.BEFORE_EXIT, {
-                    code,
-                }));
-            });
+            // process.on('beforeExit', (code: number) => {
+            //     console.log('TESTING!!!');
+            //     observer.next(this.createMessagePayload(ParentEvent.BEFORE_EXIT, {
+            //         code,
+            //     }));
+            // });
 
             // Listens for 'disconnect' events
             process.on('disconnect', () => {

--- a/lib/Transporter.ts
+++ b/lib/Transporter.ts
@@ -1,6 +1,7 @@
 import { Observable, Observer } from 'rxjs';
 import { filter, share } from 'rxjs/operators';
 import { BaseTransporter } from './BaseTransporter';
+import { ParentEvent } from './tools/Events';
 import { Message } from './tools/Message';
 
 /**
@@ -66,6 +67,42 @@ export class Transporter extends BaseTransporter {
             process.on('message', (data) => {
                 observer.next(data);
             });
+
+            // Listens for 'beforeExit' events
+            process.on('beforeExit', () => {
+                observer.next(this.createMessagePayload(ParentEvent.BEFORE_EXIT));
+            });
+
+            // Listens for 'disconnect' events
+            process.on('disconnect', () => {
+                observer.next(this.createMessagePayload(ParentEvent.DISCONNECT));
+            });
+
+            // Listens for 'exit' events
+            process.on('exit', (code: number) => {
+                observer.next(this.createMessagePayload(ParentEvent.EXIT, { code }));
+            });
+
+            // Listens for 'warning' events
+            process.on('warning', (warning: Error) => {
+                observer.next(this.createMessagePayload(ParentEvent.WARNING, { warning }));
+            });
+
+            // Listens for 'rejectionHandled' events
+            process.on('rejectionHandled', (promise: Promise<any>) => {
+                observer.next(this.createMessagePayload(ParentEvent.REJECTION_HANDLED, { }));
+            });
+
+            // Listens for 'unhandledRejection' events
+            process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
+                observer.next(this.createMessagePayload(ParentEvent.UNHANDLED_REJECTION, { reason, promise }));
+            });
+
+            // Listens for 'uncaughtException' events
+            process.on('uncaughtException', (error: Error) => {
+                observer.next(this.createMessagePayload(ParentEvent.UNCAUGHT_EXCEPTION, { error }));
+            });
+
         });
 
         // Ensure observable is not recreated for each subscription

--- a/lib/Transporter.ts
+++ b/lib/Transporter.ts
@@ -8,16 +8,16 @@ import { Message } from './tools/Message';
  * Creates an wrapper around NodeJS.Process to allow easy communication to parent process
  *
  * @export
- * @class ForkTransporter
+ * @class Transporter
  */
 export class Transporter extends BaseTransporter {
 
     private _channel: Observable<Message>;
 
     /**
-     * Creates an instance of ForkTransporter.
+     * Creates an instance of Transporter.
      *
-     * @memberof ForkTransporter
+     * @memberof Transporter
      */
     public constructor(logger?: any) {
         super(logger);
@@ -30,7 +30,7 @@ export class Transporter extends BaseTransporter {
      *
      * @param {string} command
      * @returns {Observable}
-     * @memberof ForkTransporter
+     * @memberof Transporter
      */
     public channel(command: string) {
         this.log(`Creating command channel. [command: ${command}]`);
@@ -43,7 +43,7 @@ export class Transporter extends BaseTransporter {
      *
      * @param {string} command
      * @param {*} data
-     * @memberof ForkTransporter
+     * @memberof Transporter
      */
     public emit(command: string, data: any = {}) {
         this.log(`Emitting command. [command: ${command}] [data: ${JSON.stringify(data)}]`);
@@ -59,7 +59,7 @@ export class Transporter extends BaseTransporter {
      * Setup command channel
      *
      * @protected
-     * @memberof ForkTransporter
+     * @memberof Transporter
      */
     protected setup() {
         // Create observable to receive all mesages from parent process
@@ -69,8 +69,10 @@ export class Transporter extends BaseTransporter {
             });
 
             // Listens for 'beforeExit' events
-            process.on('beforeExit', () => {
-                observer.next(this.createMessagePayload(ParentEvent.BEFORE_EXIT));
+            process.on('beforeExit', (code: number) => {
+                observer.next(this.createMessagePayload(ParentEvent.BEFORE_EXIT, {
+                    code,
+                }));
             });
 
             // Listens for 'disconnect' events

--- a/lib/tools/Events.ts
+++ b/lib/tools/Events.ts
@@ -4,3 +4,13 @@ export enum ChildEvent {
     ERROR       = 'error',
     EXIT        = 'exit',
 }
+
+export enum ParentEvent {
+    BEFORE_EXIT         = 'beforeExit',
+    DISCONNECT          = 'disconnect',
+    EXIT                = 'exit',
+    WARNING             = 'warning',
+    REJECTION_HANDLED   = 'rejectionHandled',
+    UNCAUGHT_EXCEPTION  = 'uncaughtException',
+    UNHANDLED_REJECTION = 'unhandledRejection',
+}

--- a/lib/tools/Events.ts
+++ b/lib/tools/Events.ts
@@ -1,0 +1,6 @@
+export enum ChildEvent {
+    CLOSE       = 'close',
+    DISCONNECT  = 'disconnect',
+    ERROR       = 'error',
+    EXIT        = 'exit',
+}

--- a/test/Transporter.test.ts
+++ b/test/Transporter.test.ts
@@ -125,5 +125,28 @@ describe('Transporter', () => {
                     done();
                 });
         });
+
+        // TODO: Uncomment when beforeExit event is working
+        // it('beforeExit', (done) => {
+        //     childProcess = fork(childLocation + '/child4', [], {
+        //         env: {
+        //             TEST: '6',
+        //         },
+        //     });
+
+        //     const transporter = new ForkTransporter(childProcess);
+
+        //     transporter.channel('ran')
+        //         .pipe(first())
+        //         .subscribe(() => {
+        //             done();
+        //         });
+
+        //     transporter.channel('exit')
+        //         .pipe(first())
+        //         .subscribe(() => {
+        //             console.log('child process is exited.');
+        //         });
+        // });
     });
 });

--- a/test/Transporter.test.ts
+++ b/test/Transporter.test.ts
@@ -91,22 +91,39 @@ describe('Transporter', () => {
                 });
         });
 
-        // it('unhandledRejection', (done) => {
-        //     childProcess = fork(childLocation + '/child4', [], {
-        //         env: {
-        //             TEST: '3',
-        //         },
-        //     });
+        it('unhandledRejection', (done) => {
+            childProcess = fork(childLocation + '/child4', [], {
+                env: {
+                    TEST: '4',
+                },
+            });
 
-        //     const transporter = new ForkTransporter(childProcess);
+            const transporter = new ForkTransporter(childProcess);
 
-        //     transporter.channel('ran')
-        //         .pipe(first())
-        //         .subscribe(({ data }) => {
-        //             assert.ok(data.reason, 'reason does not exist in data');
-        //             assert.ok(data.promise, 'promise does not exist in data');
-        //             done();
-        //         });
-        // });
+            transporter.channel('ran')
+                .pipe(first())
+                .subscribe(({ data }) => {
+                    assert.ok(data.reason, 'reason does not exist in data');
+                    assert.ok(data.promise, 'promise does not exist in data');
+                    done();
+                });
+        });
+
+        it('rejectionHandled', (done) => {
+            childProcess = fork(childLocation + '/child4', [], {
+                env: {
+                    TEST: '5',
+                },
+            });
+
+            const transporter = new ForkTransporter(childProcess);
+
+            transporter.channel('ran')
+                .pipe(first())
+                .subscribe(({ data }) => {
+                    assert.ok(data.promise, 'promise does not exist in data');
+                    done();
+                });
+        });
     });
 });

--- a/test/Transporter.test.ts
+++ b/test/Transporter.test.ts
@@ -8,18 +8,18 @@ const childLocation = path.resolve(__dirname, 'tools');
 
 describe('Transporter', () => {
 
-    let process: ChildProcess;
+    let childProcess: ChildProcess;
 
     afterEach(() => {
-        if (process) {
-            process.kill();
+        if (childProcess) {
+            childProcess.kill();
         }
     });
 
     it('Properly send command', (done) => {
-        process = fork(childLocation + '/child1');
+        childProcess = fork(childLocation + '/child1');
 
-        const transporter = new ForkTransporter(process);
+        const transporter = new ForkTransporter(childProcess);
 
         transporter.channel('TestCommand')
             .pipe(first())
@@ -37,5 +37,76 @@ describe('Transporter', () => {
         Transporter.enableLog = true;
 
         Transporter.emit('test');
+    });
+
+    describe('Default Events', () => {
+
+        it('exit', (done) => {
+            childProcess = fork(childLocation + '/child4', [], {
+                env: {
+                    TEST: '1',
+                },
+            });
+
+            const transporter = new ForkTransporter(childProcess);
+
+            transporter.channel('ran')
+                .pipe(first())
+                .subscribe(() => {
+                    done();
+                });
+        });
+
+        it('uncaughtException', (done) => {
+            childProcess = fork(childLocation + '/child4', [], {
+                env: {
+                    TEST: '2',
+                },
+            });
+
+            const transporter = new ForkTransporter(childProcess);
+
+            transporter.channel('ran')
+                .pipe(first())
+                .subscribe(({ data }) => {
+                    assert.ok(data.error, 'error does not exist in data');
+                    done();
+                });
+        });
+
+        it('warning', (done) => {
+            childProcess = fork(childLocation + '/child4', [], {
+                env: {
+                    TEST: '3',
+                },
+            });
+
+            const transporter = new ForkTransporter(childProcess);
+
+            transporter.channel('ran')
+                .pipe(first())
+                .subscribe(({ data }) => {
+                    assert.ok(data.warning, 'warning does not exist in data');
+                    done();
+                });
+        });
+
+        // it('unhandledRejection', (done) => {
+        //     childProcess = fork(childLocation + '/child4', [], {
+        //         env: {
+        //             TEST: '3',
+        //         },
+        //     });
+
+        //     const transporter = new ForkTransporter(childProcess);
+
+        //     transporter.channel('ran')
+        //         .pipe(first())
+        //         .subscribe(({ data }) => {
+        //             assert.ok(data.reason, 'reason does not exist in data');
+        //             assert.ok(data.promise, 'promise does not exist in data');
+        //             done();
+        //         });
+        // });
     });
 });

--- a/test/tools/child4/child4.ts
+++ b/test/tools/child4/child4.ts
@@ -40,7 +40,7 @@ if (process.env.TEST === '3') {
     process.emitWarning('Test 3 warning');
 }
 
-if (process.env.TEST === '0') {
+if (process.env.TEST === '4') {
     Transporter.channel('unhandledRejection')
     .pipe(first())
     .subscribe(({ data }) => {
@@ -50,6 +50,31 @@ if (process.env.TEST === '0') {
     });
 
     const testPromise = new Promise((resolve, reject) => {
-        throw new Error('Test error');
+        throw new Error('Test 4 error');
+    });
+}
+
+if (process.env.TEST === '5') {
+    Transporter.channel('rejectionHandled')
+    .pipe(first())
+    .subscribe(({ data }) => {
+        console.log('rejectionHandled received...');
+        console.log('data: ', JSON.stringify(data));
+        Transporter.emit('ran', data);
+    });
+
+    Transporter.channel('unhandledRejection')
+    .pipe(first())
+    .subscribe(({ data }) => {
+        console.log('unhandledRejection received...');
+
+        data.promise
+            .catch((err) => {
+                console.log('error: ', err);
+            });
+    });
+
+    const testPromise = new Promise((resolve, reject) => {
+        reject('Test rejection.');
     });
 }

--- a/test/tools/child4/child4.ts
+++ b/test/tools/child4/child4.ts
@@ -1,0 +1,55 @@
+import { first } from 'rxjs/operators';
+import { Transporter } from '../../../lib';
+
+console.log('test process running...', 'Test: ' + process.env.TEST);
+
+if (process.env.TEST === '1') {
+    Transporter.channel('exit')
+    .pipe(first())
+    .subscribe(({ data }) => {
+        console.log('exit received...');
+        Transporter.emit('ran', data);
+    });
+
+    process.exit(0);
+}
+
+if (process.env.TEST === '2') {
+    Transporter.channel('uncaughtException')
+    .pipe(first())
+    .subscribe(({ data }) => {
+        console.log('uncaughtException received...');
+        console.log('data: ', JSON.stringify(data));
+
+        Transporter.emit('ran', data);
+    });
+
+    throw new Error('Test 2 error');
+}
+
+if (process.env.TEST === '3') {
+    Transporter.channel('warning')
+    .pipe(first())
+    .subscribe(({ data }) => {
+        console.log('warning received...');
+        console.log('data: ', JSON.stringify(data));
+
+        Transporter.emit('ran', data);
+    });
+
+    process.emitWarning('Test 3 warning');
+}
+
+if (process.env.TEST === '0') {
+    Transporter.channel('unhandledRejection')
+    .pipe(first())
+    .subscribe(({ data }) => {
+        console.log('unhandledRejection received...');
+        console.log('data: ', JSON.stringify(data));
+        Transporter.emit('ran', data);
+    });
+
+    const testPromise = new Promise((resolve, reject) => {
+        throw new Error('Test error');
+    });
+}

--- a/test/tools/child4/child4.ts
+++ b/test/tools/child4/child4.ts
@@ -78,3 +78,16 @@ if (process.env.TEST === '5') {
         reject('Test rejection.');
     });
 }
+
+if (process.env.TEST === '6') {
+    Transporter.channel('beforeExit')
+        .pipe(first())
+        .subscribe(({ data }) => {
+            console.log('beforeExit received...');
+            Transporter.emit('ran', data);
+        });
+
+    process.on('beforeExit', () => {
+        console.log('IN EVENT EMITTER');
+    });
+}

--- a/test/tools/child4/index.js
+++ b/test/tools/child4/index.js
@@ -1,0 +1,3 @@
+// Import typescript test file
+require('ts-node/register');
+require('./child4');

--- a/test/tools/child5/child5.ts
+++ b/test/tools/child5/child5.ts
@@ -1,0 +1,9 @@
+console.log('test process running...', 'Test: ' + process.env.TEST);
+
+if (process.env.TEST === '1') {
+    process.exit(0);
+}
+
+if (process.env.TEST === '2') {
+    process.disconnect();
+}

--- a/test/tools/child5/index.js
+++ b/test/tools/child5/index.js
@@ -1,0 +1,3 @@
+// Import typescript test file
+require('ts-node/register');
+require('./child5');


### PR DESCRIPTION
This PR completes #3 & #4 

- Transporter now hooks into default events emitted by NodeJS.Process
- ForkTransporter now hooks into default events emitted by ChildProcess
- All default events are documented in #4 


**Unable to implement:**
- Cannot add default event "**beforeExit**" because the observable prevents the process from exiting when no work is scheduled because the observable is still running.
- Cannot create a unit test for default event "**disconnect**" on Transporter because there is no way of sending a message to the parent process once the IPC channel is disconnected.
